### PR TITLE
Re-apply tweaks on every pause render

### DIFF
--- a/scripts/pause-tweaks.mjs
+++ b/scripts/pause-tweaks.mjs
@@ -217,16 +217,26 @@ function ready() {
         }
     });
 	
+	applyAll();
+
+	// Foundry v13+ re-renders the GamePause ApplicationV2 every time the pause
+	// state toggles (_replaceHTML -> replaceChildren rebuilds img + figcaption),
+	// which discards the tweaks applied above. Re-apply them on every render so
+	// they persist past the first pause.
+	Hooks.on("renderGamePause", applyAll);
+}
+
+function applyAll() {
 	setupSpin();
 	updateHeight(game.settings.get(modulename, 'pause-height'));
 	updateScale(game.settings.get(modulename, 'pause-scale'));
 	updateSpinSpeed(game.settings.get(modulename, 'pause-spinspeed'));
 	updateBGSize(game.settings.get(modulename, 'pause-smallerbg'));
 	updateSpin(game.settings.get(modulename, 'pause-nospin'));
+	updateSpinDirection(game.settings.get(modulename, 'pause-spindirection'));
 	updateText(game.settings.get(modulename, 'pause-text'));
 	updateImg(game.settings.get(modulename, 'pause-img'));
 	updatePulse(game.settings.get(modulename, 'pause-pulse'));
-	
 }
-	
+
 Hooks.on("ready", ready);


### PR DESCRIPTION
The GamePause ApplicationV2 rebuilds its img/figcaption on each pause toggle, discarding tweaks applied once on ready, so custom image/text/spin reverted to defaults after the first pause. Move the apply logic into applyAll() and run it on every renderGamePause render.

Also fixes spin direction.